### PR TITLE
Fixing State Propagation Inconsistencies

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,10 +1,21 @@
+// swift-tools-version:4.2
 import PackageDescription
 
 let package = Package(
-    name: "ReSwift",
-    exclude: [
-      "ReSwiftTests",
-      "Carthage",
-      "Docs"
-    ]
+	name: "ReSwift",
+	// platforms: [.iOS("8.0"), .macOS("10.10"), tvOS("9.0"), .watchOS("2.0")],
+	products: [
+		.library(name: "ReSwift", targets: ["ReSwift"])
+	],
+	targets: [
+		.target(
+			name: "ReSwift",
+			path: "",
+			exclude: [
+			  "ReSwiftTests",
+			  "Carthage",
+			  "Docs"
+			]
+		)
+	]
 )

--- a/ReSwift/CoreTypes/Store.swift
+++ b/ReSwift/CoreTypes/Store.swift
@@ -6,6 +6,8 @@
 //  Copyright © 2015 DigiTales. All rights reserved.
 //
 
+import Foundation
+
 /**
  This class is the default implementation of the `Store` protocol. You will use this store in most
  of your applications. You shouldn't need to implement your own store.

--- a/ReSwift/CoreTypes/Store.swift
+++ b/ReSwift/CoreTypes/Store.swift
@@ -23,15 +23,15 @@ open class Store<State: StateType>: StoreType {
 
     /*private (set)*/ public var state: State! {
         didSet {
+			isUpdatingSubscribers = true
             subscriptions.forEach {
-				isUpdatingSubscribers = true
                 if $0.subscriber == nil {
                     subscriptions.remove($0)
                 } else {
                     $0.newValues(oldState: oldValue, newState: state)
                 }
-				isUpdatingSubscribers = false
             }
+			isUpdatingSubscribers = false
         }
     }
 

--- a/ReSwift/CoreTypes/Store.swift
+++ b/ReSwift/CoreTypes/Store.swift
@@ -196,14 +196,13 @@ open class Store<State: StateType>: StoreType {
 			return
 		}
 
-		guard avoidDispatchesDuringSubscriberUpdates && isUpdatingSubscribers else {
+		if avoidDispatchesDuringSubscriberUpdates && isUpdatingSubscribers {
 			DispatchQueue.main.async {
 				self.dispatchFunction(action)
 			}
-			return
+		} else {
+			dispatchFunction(action)
 		}
-
-		dispatchFunction(action)
     }
 
     open func dispatch(_ actionCreatorProvider: @escaping ActionCreator) {

--- a/ReSwiftTests/StoreTests.swift
+++ b/ReSwiftTests/StoreTests.swift
@@ -56,7 +56,9 @@ class DeInitStore<State: StateType>: Store<State> {
                 reducer: reducer,
                 state: state,
                 middleware: [],
-                automaticallySkipsRepeats: false)
+                automaticallySkipsRepeats: false,
+				alwaysDispatchOnMainQueue: false,
+				avoidDispatchesDuringSubscriberUpdates: false)
             self.deInitAction = deInitAction
     }
 
@@ -64,12 +66,16 @@ class DeInitStore<State: StateType>: Store<State> {
         reducer: @escaping Reducer<State>,
         state: State?,
         middleware: [Middleware<State>],
-        automaticallySkipsRepeats: Bool) {
+        automaticallySkipsRepeats: Bool,
+        alwaysDispatchOnMainQueue: Bool,
+        avoidDispatchesDuringSubscriberUpdates: Bool) {
             super.init(
                 reducer: reducer,
                 state: state,
                 middleware: middleware,
-                automaticallySkipsRepeats: automaticallySkipsRepeats)
+                automaticallySkipsRepeats: automaticallySkipsRepeats,
+				alwaysDispatchOnMainQueue: alwaysDispatchOnMainQueue,
+				avoidDispatchesDuringSubscriberUpdates: avoidDispatchesDuringSubscriberUpdates)
     }
 }
 


### PR DESCRIPTION
When propagating a state update to all subscribers, it can happen that an action is dispatched as a reaction to said state update. This action is then immediately processed and the state changes it might lead to are then communicated to all subscribers _before_ the prior state changes.
This can lead (and has led) to unexpected (and actually impossible) state changes in the subscribers and this behavior is considered a bug in `ReSwift`.

Please note that the solution proposed in this PR only works when all actions are dispatched on the main thread, which is a caveat that we are willing to take since it was our default behavior anyway.